### PR TITLE
메인페이지 우측 post, studio TOP5 구현 완료

### DIFF
--- a/src/main/java/com/example/Apollon/domain/home/controller/HomeController.java
+++ b/src/main/java/com/example/Apollon/domain/home/controller/HomeController.java
@@ -1,5 +1,10 @@
 package com.example.Apollon.domain.home.controller;
 
+import com.example.Apollon.domain.post.entity.BoardType;
+import com.example.Apollon.domain.post.entity.Post;
+import com.example.Apollon.domain.post.entity.PostComment;
+import com.example.Apollon.domain.post.service.PostCommentService;
+import com.example.Apollon.domain.post.service.PostService;
 import com.example.Apollon.domain.studio.entity.Studio;
 import com.example.Apollon.domain.studio.service.StudioService;
 import lombok.RequiredArgsConstructor;
@@ -9,14 +14,23 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.security.Principal;
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
 public class HomeController {
     private final StudioService studioService;
+    private final PostService postService;
 
     @GetMapping("/")
     public String goMain(Model model, Principal principal) {
+        // 메인페이지 우측에 커뮤니티(자주묻는질문), 스튜디오(방문자TOP) 가져오기
+        List<Post> top5NoticePosts = this.postService.getTop5PostsByViewAndBoardType(BoardType.공지);
+        List<Studio> top5Studios = this.studioService.getTop5StudiosByVisit();
+
+        model.addAttribute("top5NoticePosts", top5NoticePosts);
+        model.addAttribute("top5Studios", top5Studios);
+
         // 스튜디오 진입 시 로그인된 회원 스튜디외의 차단 상태 판단을 위해 작성
         if(principal != null) {
             Studio studio = this.studioService.getStudioByMemberUsername(principal.getName());

--- a/src/main/java/com/example/Apollon/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/Apollon/domain/post/repository/PostRepository.java
@@ -7,9 +7,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAll(Pageable pageable);
     Page<Post> findByBoardType(BoardType boardType, Pageable pageable);
 
+    List<Post> findTop5ByBoardTypeOrderByViewDesc(BoardType boardType);
 }

--- a/src/main/java/com/example/Apollon/domain/post/service/PostService.java
+++ b/src/main/java/com/example/Apollon/domain/post/service/PostService.java
@@ -89,4 +89,7 @@ public class PostService {
         }
     }
 
+    public List<Post> getTop5PostsByViewAndBoardType(BoardType boardType) {
+        return this.postRepository.findTop5ByBoardTypeOrderByViewDesc(boardType);
+    }
 }

--- a/src/main/java/com/example/Apollon/domain/studio/repository/StudioRepository.java
+++ b/src/main/java/com/example/Apollon/domain/studio/repository/StudioRepository.java
@@ -17,4 +17,6 @@ public interface StudioRepository extends JpaRepository<Studio, Long> {
     boolean existsByMember(Member member);
 
     Optional<Studio> findByMember(Member member);
+
+    List<Studio> findTop5ByOrderByVisitDesc();
 }

--- a/src/main/java/com/example/Apollon/domain/studio/service/StudioService.java
+++ b/src/main/java/com/example/Apollon/domain/studio/service/StudioService.java
@@ -82,4 +82,7 @@ public class StudioService {
 
         this.studioRepository.save(studio);
     }
+    public List<Studio> getTop5StudiosByVisit() {
+        return this.studioRepository.findTop5ByOrderByVisitDesc();
+    }
 }

--- a/src/main/resources/static/mainPage.css
+++ b/src/main/resources/static/mainPage.css
@@ -30,7 +30,6 @@ input: focus {
 .mainPage_container {
     /* footer에 가려지지 않기 위함 */
     height: calc(100vh - 50px);
-    overflow-y: auto;
 }
 
 .mainPage_slide_container {
@@ -40,7 +39,7 @@ input: focus {
   overflow: hidden;
   position: relative;
   background-color: #000;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2)
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 .banner_inner_section {
@@ -147,36 +146,86 @@ input: focus {
     height: 560px;
 }
 
+/* 자주찾는 질문 */
 .body_side_notice {
     width: 270px; height: 240px;
     display: flex;
     flex-direction: column;
     overflow: hidden;
 }
+
 .side_notice, .side_news {
-    width: 150px; height: 30px;
+    width: 230px; height: 30px;
     display: flex;
     align-items: center;
     color: #111;
-    font-size: 22px;
-    font-weight: 500;
+    font-size: 20px;
+    font-weight: 700;
     margin-left: 20px;
 }
 
 .notice_box {
     margin-left: 20px;
+    margin-top: 20px;
     width: 230px; height: 200px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
 }
 
 .notice_box > li {
     color: #111;
-    font-size: 14px;
+    font-size: 1.08rem;
     font-weight: 500;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
+.notice_box > li > a {
+    cursor: pointer;
+}
+
+/* 방문자 TOP5 */
+.body_side_studio {
+    width: 270px; height: 240px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    margin-top: 75px;
+}
+
+.side_studio, .side_news {
+    width: 230px; height: 30px;
+    display: flex;
+    align-items: center;
+    color: #111;
+    font-size: 20px;
+    font-weight: 700;
+    margin-left: 20px;
+}
+
+.studio_box {
+    margin-left: 20px;
+    margin-top: 20px;
+    width: 230px; height: 200px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.studio_box > li {
+    color: #111;
+    font-size: 1.08rem;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.studio_box > li > a {
+    cursor: pointer;
+}
 
 /* 추가 내용 */
 .p_container {

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -26,7 +26,7 @@
                  th:href="@{'/studio/' + ${#authentication.principal.username}}">스튜디오</a>
 
               <a th:if="${#authorization.expression('isAnonymous()')}"
-                 onclick="return confirm('로그인이 필요한 서비스입니다.');"
+                 onclick="return confirm('스튜디오를 방문하시려면 로그인이 필요합니다.');"
                  th:href="@{/member/login}">스튜디오</a>
             </li>
           </ul>

--- a/src/main/resources/templates/mainPage.html
+++ b/src/main/resources/templates/mainPage.html
@@ -73,10 +73,27 @@
         </div>
         <div class="mainPage_side_container">
           <div class="body_side_notice">
-            <div class="side_notice">Notice</div>
+            <div class="side_notice">[자주 찾는 질문 TOP5❓]</div>
             <ul class="notice_box">
-              <li><a href="/post/list">[자주 찾는 질문] 비밀번호 찾기 어떻게 하나요?</a></li>
-              <li><a href="/post/list">[자주 찾는 질문] 비회원은 노래 전체 듣기 불가능 하나요?</a></li>
+              <li th:each="post, iterStat : ${top5NoticePosts}">
+                <a th:href="@{|/post/detail/${post.id}|}"
+                   th:text="${iterStat.index + 1} + '. ' + ${post.title}"></a>
+              </li>
+            </ul>
+          </div>
+          <div class="body_side_studio">
+            <div class="side_studio">[스튜디오 TOP5👍]</div>
+            <ul class="studio_box">
+              <li th:each="studio, iterStat : ${top5Studios}">
+                <a th:href="@{|/studio/${studio.member.username}|}"
+                   th:text="${iterStat.index + 1} + '. ' + ${studio.member.nickname} + ' - 방문자수: ' + ${studio.visit}"
+                   th:if="${#authorization.expression('isAuthenticated()')}">
+                </a>
+                <a th:text="${iterStat.index + 1} + '. ' + ${studio.member.nickname} + ' - 방문자수: ' + ${studio.visit}"
+                   th:if="${#authorization.expression('isAnonymous()')}"
+                   onclick="alert('스튜디오를 방문하시려면 로그인이 필요합니다.'); return false;">
+                </a>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
- 메인페이지 우측 자주 찾는 질문 TOP5, 스튜디오 TOP5 구현 완료
- 질문 Post는 view(방문자) 순으로 높은 것부터 공지 게시판인 것만 분류
- 스튜디오 Studio는 visit(방문자) 순으로 높은 것부터 분류
- 각 텍스트별로 해당 상세 페이지 이동 가능 (스튜디오는 미 로그인시 접근불가) 